### PR TITLE
To .Net 5

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -1,33 +1,38 @@
 ﻿@page "/"
 @inject NavigationManager navigationManager
-@using BlazorInputFile
 @using System.Threading
 
-<div class="banner">
-    <span class="title">Source Generator Playground<span class="version"> - @ThisAssembly.AssemblyInformationalVersion</span></span>
-    Load sample: <select value="@_currentSample" @onchange="LoadSample">
-        @{
-            var index = 0;
-        }
-        @foreach (string sample in SamplesLoader.Samples)
-        {
-            <option value="@(index++)">@sample</option>
-        }
-    </select>
-    <span class="about">
-        by <a target="_blank" href="https://twitter.com/davidwengier">@@davidwengier</a>
-        - <a target="_blank" href="https://github.com/davidwengier/SourceGeneratorPlayground">GitHub</a>
-    </span>
-</div>
+<div class="banner top-row px-4">
+        <span class="title">Source Generator Playground<span class="version"> - @ThisAssembly.AssemblyInformationalVersion</span></span>
+        Load sample: <select value="@_currentSample" @onchange="LoadSample">
+            @{
+                var index = 0;
+            }
+            @foreach (string sample in SamplesLoader.Samples)
+            {
+                <option value="@(index++)">@sample</option>
+            }
+        </select>
+        <span class="about">
+            by <a target="_blank" href="https://twitter.com/davidwengier">@@davidwengier</a>
+            - <a target="_blank" href="https://github.com/davidwengier/SourceGeneratorPlayground">GitHub</a>
+        </span>
+    </div>
+    @*<div class="top-row px-4">
+        <a href="http://blazor.net" target="_blank" class="ml-md-auto">About</a>
+    </div>*@
 
-<div class="parent">
+    @*<div class="content px-4"> </div>*@
+
+<div class="content parent px-4">
     <div class="code-header"><span class="header">Program Code</span><div class="fileUpload btn btn-secondary"><span>Load</span><InputFile OnChange="HandleCodeFileSelected" /></div></div>
     <div class="code"><MonacoEditor @ref="codeEditor" Id="code-editor" ConstructionOptions="EditorConstructionOptions" OnKeyUp="OnKeyUp" /></div>
     <div class="generator-header"><span class="header">Source Generator</span><div class="fileUpload btn btn-secondary"><span>Load</span><InputFile OnChange="HandleGeneratorFileSelected" /></div></div>
     <div class="generator"><MonacoEditor @ref="generator" Id="generator" ConstructionOptions="EditorConstructionOptions" OnKeyUp="OnKeyUp" /></div>
     <div class="program-output-header"><span class="header">Output</span></div>
     <div class="program-output"><MonacoEditor @ref="programOutput" Id="program-output" ConstructionOptions="EditorConstructionOptions" /></div>
-    <div class="generator-output-header"><span class="header">Generated Output</span>
+    <div class="generator-output-header">
+        <span class="header">Generated Output</span>
         <div class="refresh">
             <span>
                 <input type="checkbox" @bind="_autoRefresh" /> Auto
@@ -97,7 +102,7 @@
         {
             options.Value = gen;
 
-        _ = Update(default);
+            _ = Update(default);
         }
 
 
@@ -158,19 +163,19 @@
         await generatorOutput.SetValue(runner.GeneratorOutput);
     }
 
-    private async Task HandleCodeFileSelected(IFileListEntry[] files)
+    private async Task HandleCodeFileSelected(InputFileChangeEventArgs args)
     {
-        await LoadFile(files[0], codeEditor);
+        await LoadFile(args.File, codeEditor);
     }
 
-    private async Task HandleGeneratorFileSelected(IFileListEntry[] files)
+    private async Task HandleGeneratorFileSelected(InputFileChangeEventArgs args)
     {
-        await LoadFile(files[0], generator);
+        await LoadFile(args.File, generator);
     }
 
-    private async Task LoadFile(IFileListEntry file, MonacoEditor editor)
+    private async Task LoadFile(IBrowserFile file, MonacoEditor editor)
     {
-        using (var reader = new System.IO.StreamReader(file.Data))
+        using (var reader = new System.IO.StreamReader(file.OpenReadStream()))
         {
             await editor.SetValue(await reader.ReadToEndAsync());
         }

--- a/Program.cs
+++ b/Program.cs
@@ -11,7 +11,7 @@ namespace SourceGeneratorPlayground
         public static async Task Main(string[] args)
         {
             var builder = WebAssemblyHostBuilder.CreateDefault(args);
-            builder.RootComponents.Add<App>("app");
+            builder.RootComponents.Add<App>("#app");
 
             builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 

--- a/Runner.cs
+++ b/Runner.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -35,7 +36,8 @@ namespace SourceGeneratorPlayground
         {
             if (s_references == null)
             {
-                s_references = await GetReferences(baseUri);
+                //s_references = await GetReferences(baseUri);
+                s_references = await GetReferencesFromBootDoc(baseUri);
             }
 
             this.ProgramOutput = "";
@@ -235,6 +237,11 @@ namespace SourceGeneratorPlayground
                 BaseAddress = new Uri(baseUri)
             };
 
+            using var bootResponse = await client.GetAsync("_framework/blazor.boot.json");
+            bootResponse.EnsureSuccessStatusCode();
+            using var boot = JsonDocument.Parse(await bootResponse.Content.ReadAsStringAsync());
+            var assemblies = boot.RootElement.GetProperty("resources").GetProperty("assembly").EnumerateObject().Select(jp => jp.Name);
+
             var references = new List<MetadataReference>();
             try
             {
@@ -274,6 +281,45 @@ namespace SourceGeneratorPlayground
                     references.Add(MetadataReference.CreateFromStream(stream));
 
                 }
+            } catch (Exception e)
+            {
+                var str = e.ToString();
+                throw;
+            }
+
+            return references;
+        }
+
+        private async Task<List<MetadataReference>> GetReferencesFromBootDoc(string baseUri)
+        {
+            Assembly[]? refs = AppDomain.CurrentDomain.GetAssemblies();
+            using var client = new HttpClient
+            {
+                BaseAddress = new Uri(baseUri)
+            };
+
+            var references = new List<MetadataReference>();
+            try
+            {
+            using var bootResponse = await client.GetAsync("_framework/blazor.boot.json");
+            bootResponse.EnsureSuccessStatusCode();
+            using var boot = JsonDocument.Parse(await bootResponse.Content.ReadAsStringAsync());
+            var assemblies = boot.RootElement.GetProperty("resources").GetProperty("assembly").EnumerateObject().Select(jp => jp.Name);
+                //.Concat(boot.RootElement.GetProperty("resources").GetProperty("lazyAssembly").EnumerateObject().Select(jp => jp.Name));
+
+            try
+            {
+                foreach (var assemblyName in assemblies)
+                {
+                    Stream? stream = await client.GetStreamAsync($"_framework/{assemblyName}");
+                    references.Add(MetadataReference.CreateFromStream(stream));
+
+                }
+            } catch (Exception e)
+            {
+                var str = e.ToString();
+                throw;
+            }
             } catch (Exception e)
             {
                 var str = e.ToString();

--- a/Shared/MainLayout.razor
+++ b/Shared/MainLayout.razor
@@ -1,3 +1,7 @@
 ﻿@inherits LayoutComponentBase
 
-@Body
+<div class="page">
+    <div class="main">
+        @Body
+    </div>
+</div>

--- a/Shared/MainLayout.razor.css
+++ b/Shared/MainLayout.razor.css
@@ -1,0 +1,72 @@
+﻿.page {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+.main {
+    flex: 1;
+}
+
+.sidebar {
+    background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
+}
+
+.top-row {
+    background-color: #f7f7f7;
+    border-bottom: 1px solid #d6d5d5;
+    justify-content: flex-end;
+    height: 3.5rem;
+    display: flex;
+    align-items: center;
+}
+
+    .top-row ::deep a, .top-row .btn-link {
+        white-space: nowrap;
+        margin-left: 1.5rem;
+    }
+
+    .top-row a:first-child {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+@media (max-width: 767.98px) {
+    .top-row:not(.auth) {
+        display: none;
+    }
+
+    .top-row.auth {
+        justify-content: space-between;
+    }
+
+    .top-row a, .top-row .btn-link {
+        margin-left: 0;
+    }
+}
+
+@media (min-width: 768px) {
+    .page {
+        flex-direction: row;
+        /* NOTE: added this o make the page fill */
+        height: 100vh;
+    }
+
+    .sidebar {
+        width: 250px;
+        height: 100vh;
+        position: sticky;
+        top: 0;
+    }
+
+    .top-row {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+    }
+
+    .main > div {
+        padding-left: 2rem !important;
+        padding-right: 1.5rem !important;
+    }
+}

--- a/SourceGeneratorPlayground.csproj
+++ b/SourceGeneratorPlayground.csproj
@@ -1,10 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <RazorLangVersion>3.0</RazorLangVersion>
-    <LangVersion>preview</LangVersion>
-    <BlazorWebAssemblyEnableLinking>false</BlazorWebAssemblyEnableLinking>
+    <TargetFramework>net5.0</TargetFramework>
+    <!--<LangVersion>preview</LangVersion>-->
+    <!--<BlazorWebAssemblyEnableLinking>false</BlazorWebAssemblyEnableLinking>-->
+    <PublishSingleFile>false</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed>
+    <PublishReadyToRun>false</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,24 +15,25 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BlazorInputFile" Version="0.2.0" />
-    <PackageReference Include="BlazorMonaco" Version="1.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.1" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
+    <PackageReference Include="BlazorMonaco" Version="1.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.1" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.2.31">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0-3.final" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/SourceGeneratorPlayground.csproj
+++ b/SourceGeneratorPlayground.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net5.0</TargetFramework>
     <!--<LangVersion>preview</LangVersion>-->
     <!--<BlazorWebAssemblyEnableLinking>false</BlazorWebAssemblyEnableLinking>-->
-    <PublishSingleFile>false</PublishSingleFile>
+    <!--<PublishSingleFile>false</PublishSingleFile>-->
     <PublishTrimmed>false</PublishTrimmed>
-    <PublishReadyToRun>false</PublishReadyToRun>
+    <!--<PublishReadyToRun>false</PublishReadyToRun>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/_Imports.razor
+++ b/_Imports.razor
@@ -3,6 +3,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
 @using Microsoft.JSInterop
 @using SourceGeneratorPlayground

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -2,10 +2,11 @@
 
 html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    display:flex;
-    height: 98%;
+    /*display:flex;*/
+/*    height: 98%;
     width: 99%;
-    background-color: lightgray;
+*/    background-color: lightgray;
+    /*flex: auto;*/
 }
 
 a, .btn-link {
@@ -18,12 +19,16 @@ a, .btn-link {
     border-color: #1861ac;
 }
 
-app {
-    padding-left: 20px;
-    padding-top: 20px;
-    display: flex;
-    flex: 1 1;
+.content {
+    padding-top: 1.1rem;
 }
+
+/*#app {*/
+/*    padding-left: 20px;
+    padding-top: 20px;
+*//*    display: flex;
+    flex: 1 1;
+*//*}*/
 
 .valid.modified:not([type=checkbox]) {
     outline: 1px solid #26b050;
@@ -49,12 +54,12 @@ app {
     z-index: 1000;
 }
 
-#blazor-error-ui .dismiss {
-    cursor: pointer;
-    position: absolute;
-    right: 0.75rem;
-    top: 0.5rem;
-}
+    #blazor-error-ui .dismiss {
+        cursor: pointer;
+        position: absolute;
+        right: 0.75rem;
+        top: 0.5rem;
+    }
 
 .monaco-editor-container {
     height: 100%;
@@ -89,7 +94,7 @@ div.refresh div {
 .banner                  { 
     /* grid-area: 1 / 1 / 2 / 3; */
     background-color: white;
-    position: absolute;
+    /*position: absolute;*/
     top: 0;
     left: 0;
     right: 0;

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 
 <head>
@@ -10,22 +10,24 @@
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="_content/BlazorMonaco/lib/monaco-editor/min/vs/editor/editor.main.css" rel="stylesheet" />
+    <link href="SourceGeneratorPlayground.styles.css" rel="stylesheet" />
 </head>
 
 <body>
-    <app>Loading...</app>
+    <div id="app">Loading...</div>
 
     <div id="blazor-error-ui">
         An unhandled error has occurred.
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-    <script src="_framework/blazor.webassembly.js"></script>
+
     <script src="_content/BlazorMonaco/lib/monaco-editor/min/vs/loader.js"></script>
     <script>require.config({ paths: { 'vs': '_content/BlazorMonaco/lib/monaco-editor/min/vs' } });</script>
     <script src="_content/BlazorMonaco/lib/monaco-editor/min/vs/editor/editor.main.js"></script>
     <script src="_content/BlazorMonaco/jsInterop.js"></script>
-    <script src="fileinput.js"></script>
+    <script src="_framework/blazor.webassembly.js"></script>
+    <!--<script src="fileinput.js"></script>-->
 </body>
 
 </html>


### PR DESCRIPTION
I'm trying to upgrade your playground to .net 5, I'm hitting two issues:

1. the css has changed and I've tried to fix it, but it's not exactly right
2. The loading of the assemblies to get the `MetadataReference` needs changing because `Location` on the assemblies is now an empty string, I've worked around this by assuming that the `Name` of the assembly is the name of the dll on disk.
3. I've had to change the csproj options to ensure the dlls get put on disk individually

I still have to do some cleanup, but if you could already take a look? 