### PR TITLE
Add common meta tags to improve SEO

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -6,6 +6,8 @@
     <link rel="icon" type="image/png" href="favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>sourcegen.dev - Source Generator Playground - @davidwengier</title>
+    <meta name="description" content="Explore Roslyn source generators online" />
+    <meta name="keywords" content="roslyn .net source generators playground" />
     <base href="/" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
@@ -13,7 +15,7 @@
 </head>
 
 <body>
-    <app>Loading...</app>
+    <app>Source Generator Playground. Loading...</app>
 
     <div id="blazor-error-ui">
         An unhandled error has occurred.


### PR DESCRIPTION
Add common meta tags to improve SEO. I have a feeling that because the application is entirely in Blazor WebAssembly search engines are not able to extract enough context for search purposes.

fixes #5 