### PR TITLE
Caching, Async & minor changes

### DIFF
--- a/IRunner.cs
+++ b/IRunner.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+
+namespace SourceGeneratorPlayground
+{
+    internal interface IRunner
+    {
+        string ErrorText { get; }
+        string GeneratorOutput { get; }
+        string ProgramOutput { get; }
+
+        Task RunAsync(string code, string generator);
+    }
+}

--- a/IRunner.cs
+++ b/IRunner.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace SourceGeneratorPlayground
 {
@@ -8,6 +9,6 @@ namespace SourceGeneratorPlayground
         string GeneratorOutput { get; }
         string ProgramOutput { get; }
 
-        Task RunAsync(string code, string generator);
+        Task RunAsync(string code, string generator, CancellationToken cancellationToken);
     }
 }

--- a/LRUCache.cs
+++ b/LRUCache.cs
@@ -1,0 +1,154 @@
+﻿/**
+ * This code is based on
+ * https://github.com/migueldeicaza/MonoTouch.Dialog/blob/e69b806efee4ead3c39926d5164c15ae90a92b7a/MonoTouch.Dialog/Utilities/LRUCache.cs
+ * 
+ * Minor adaptations were made for compatibility with structs and classes which don't implement IDisposable
+ */
+//
+// A simple LRU cache used for tracking the images
+//
+// Authors:
+//   Miguel de Icaza (miguel@gnome.org)
+//
+// Copyright 2010 Miguel de Icaza
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+using System;
+using System.Collections.Generic;
+
+namespace MonoTouch.Dialog.Utilities
+{
+
+    public class LRUCache<TKey, TValue>
+    {
+        Dictionary<TKey, LinkedListNode<TValue>> dict;
+        Dictionary<LinkedListNode<TValue>, TKey> revdict;
+        LinkedList<TValue> list;
+        int entryLimit, sizeLimit, currentSize;
+        Func<TValue, int> slotSizeFunc;
+
+        public LRUCache(int entryLimit) : this(entryLimit, 0, null)
+        {
+        }
+
+        public LRUCache(int entryLimit, int sizeLimit, Func<TValue, int> slotSizer)
+        {
+            list = new LinkedList<TValue>();
+            dict = new Dictionary<TKey, LinkedListNode<TValue>>();
+            revdict = new Dictionary<LinkedListNode<TValue>, TKey>();
+
+            if (sizeLimit != 0 && slotSizer == null)
+                throw new ArgumentNullException("If sizeLimit is set, the slotSizer must be provided");
+
+            this.entryLimit = entryLimit;
+            this.sizeLimit = sizeLimit;
+            slotSizeFunc = slotSizer;
+        }
+
+        void Evict()
+        {
+            var last = list.Last;
+            var key = revdict[last];
+
+            if (sizeLimit > 0)
+            {
+                int size = slotSizeFunc(last.Value);
+                currentSize -= size;
+            }
+
+            dict.Remove(key);
+            revdict.Remove(last);
+            list.RemoveLast();
+            (last.Value as IDisposable)?.Dispose();
+        }
+
+        public void Purge()
+        {
+            foreach (var element in list)
+                (element as IDisposable)?.Dispose();
+
+            dict.Clear();
+            revdict.Clear();
+            list.Clear();
+            currentSize = 0;
+        }
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+
+                if (dict.TryGetValue(key, out LinkedListNode<TValue> node))
+                {
+                    list.Remove(node);
+                    list.AddFirst(node);
+
+                    return node.Value;
+                }
+                return default;
+            }
+
+            set
+            {
+                int size = sizeLimit > 0 ? slotSizeFunc(value) : 0;
+
+                if (dict.TryGetValue(key, out LinkedListNode<TValue> node))
+                {
+                    if (sizeLimit > 0 && node.Value != null)
+                    {
+                        int repSize = slotSizeFunc(node.Value);
+                        currentSize -= repSize;
+                        currentSize += size;
+                    }
+
+                    // If we already have a key, move it to the front
+                    list.Remove(node);
+                    list.AddFirst(node);
+
+                    // Remove the old value
+                    if (node.Value != null)
+                        (node.Value as IDisposable)?.Dispose();
+                    node.Value = value;
+                    while (sizeLimit > 0 && currentSize > sizeLimit && list.Count > 1)
+                        Evict();
+                    return;
+                }
+                if (sizeLimit > 0)
+                {
+                    while (sizeLimit > 0 && currentSize + size > sizeLimit && list.Count > 0)
+                        Evict();
+                }
+                if (dict.Count >= entryLimit)
+                    Evict();
+                // Adding new node
+                node = new LinkedListNode<TValue>(value);
+                list.AddFirst(node);
+                dict[key] = node;
+                revdict[node] = key;
+                currentSize += size;
+            }
+        }
+
+        public override string ToString()
+        {
+            return "LRUCache dict={0} revdict={1} list={2}";
+        }
+    }
+}

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -1,5 +1,5 @@
 ﻿@page "/"
-@inject NavigationManager navigationManager
+@inject IRunner Runner 
 @using BlazorInputFile
 @using System.Threading
 
@@ -143,19 +143,17 @@
             return;
         }
 
-        var runner = new Runner(await codeEditor.GetValue(), await generator.GetValue());
+        await Runner.RunAsync(await codeEditor.GetValue(), await generator.GetValue());
 
-        await runner.Run(navigationManager.BaseUri);
-
-        if (runner.ErrorText?.Length != 0)
+        if (Runner.ErrorText?.Length != 0)
         {
-            await programOutput.SetValue(runner.ErrorText);
+            await programOutput.SetValue(Runner.ErrorText);
         }
         else
         {
-            await programOutput.SetValue(runner.ProgramOutput);
+            await programOutput.SetValue(Runner.ProgramOutput);
         }
-        await generatorOutput.SetValue(runner.GeneratorOutput);
+        await generatorOutput.SetValue(Runner.GeneratorOutput);
     }
 
     private async Task HandleCodeFileSelected(IFileListEntry[] files)

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -143,7 +143,7 @@
             return;
         }
 
-        await Runner.RunAsync(await codeEditor.GetValue(), await generator.GetValue());
+        await Runner.RunAsync(await codeEditor.GetValue(), await generator.GetValue(), cancellationToken);
 
         if (Runner.ErrorText?.Length != 0)
         {

--- a/Program.cs
+++ b/Program.cs
@@ -14,6 +14,7 @@ namespace SourceGeneratorPlayground
             builder.RootComponents.Add<App>("app");
 
             builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+            builder.Services.AddScoped<IRunner, Runner>();
 
             await builder.Build().RunAsync();
         }


### PR DESCRIPTION
Hi @davidwengier,

first of all: Thank you for this amazing tool! It helped me countless times to quickly prototype source generators and also debug the odd "doesn't work on my machine, but it really should" issue with them.

In the process of integrating a blazor component similar to this project into a project I'm working on, I took inspiration from this project and found a few things I wanted to add:

- Caching of the source generators

When the code for the source generator doesn't change, there's no point in re-compiling it. In my use case it rarely changes, so caching is a big benefit. Since caching comes at a cost (memory), I've used a LRU cache here. The caching is performed on normalized code, so whitespace changes do not affect caching

- Support of async user code

The code I have has async parts in the user code. The existing code didn't support it, but just checking for the return type of `Main` is easy enough to work with that too.

In the process of implementing these changes, I took the liberty of transforming the runner into a service. I also sprinkled the typing cancellation token into the runner code, to abort runs that the user seems to want discarded.

I hope you like these changes. In terms of review, I suggest to work commit by commit, as each one should be relatively straightforward.

Best regards,
Stefan